### PR TITLE
feature: add ability to delete agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,18 @@ aif-workflow-helper --upload-agent my_agent --agents-dir agents
 # Get the agent ID for a specific agent by name
 aif-workflow-helper --get-agent-id my_agent
 
+# Delete a single agent (with confirmation prompt)
+aif-workflow-helper --delete-agent my_agent
+
+# Delete a single agent without confirmation
+aif-workflow-helper --delete-agent my_agent --force
+
+# Delete all agents with prefix/suffix filtering (with confirmation)
+aif-workflow-helper --delete-all-agents --prefix dev- --suffix -v1
+
+# Delete all agents without confirmation (DANGEROUS!)
+aif-workflow-helper --delete-all-agents --force
+
 # Download agents in different formats
 aif-workflow-helper --download-all-agents --format json     # Default
 aif-workflow-helper --download-all-agents --format yaml     # YAML format
@@ -165,8 +177,11 @@ create_or_update_agents_from_files(path="./agents", agent_client=client, prefix=
 --upload-all-agents             Create/update all agents from definition files
 --upload-agent NAME             Create/update a single agent from definition file
 --get-agent-id NAME             Get the agent ID for a given agent name
---prefix TEXT                   Optional prefix applied during download/upload
---suffix TEXT                   Optional suffix applied during download/upload
+--delete-agent NAME             Delete a single agent by name
+--delete-all-agents             Delete all agents (filtered by prefix/suffix if provided)
+--force                         Skip confirmation prompts when deleting agents
+--prefix TEXT                   Optional prefix applied during download/upload/delete
+--suffix TEXT                   Optional suffix applied during download/upload/delete
 --format FORMAT                 File format: json, yaml, or md (default: json)
 --log-level LEVEL               Logging level (CRITICAL, ERROR, WARNING, INFO, DEBUG, NOTSET)
 --azure-tenant-id TENANT_ID     Azure tenant ID (overrides AZURE_TENANT_ID environment variable)
@@ -212,6 +227,82 @@ aif-workflow-helper --get-agent-id my-agent \
 asst_abc123xyz456
 ========== Agent 'my-agent' has ID: asst_abc123xyz456 ==========
 ```
+
+## 🗑️ Deleting Agents
+
+### Delete a Single Agent
+
+Delete an agent by name with an interactive confirmation prompt:
+
+```bash
+# Delete with confirmation prompt
+aif-workflow-helper --delete-agent my-agent
+
+# Skip confirmation prompt with --force flag
+aif-workflow-helper --delete-agent my-agent --force
+
+# Delete agent with prefix/suffix
+aif-workflow-helper --delete-agent my-agent --prefix dev- --suffix -v1
+```
+
+**Interactive Confirmation Example:**
+
+```text
+The following agents will be deleted:
+  - my-agent
+
+Total: 1 agent(s)
+
+Are you sure you want to delete these agents? (yes/no): yes
+========== Successfully deleted agent 'my-agent' (ID: asst_abc123xyz) ==========
+```
+
+### Delete Multiple Agents
+
+Delete all agents matching a prefix/suffix pattern:
+
+```bash
+# Delete all agents starting with "dev-" (with confirmation)
+aif-workflow-helper --delete-all-agents --prefix dev-
+
+# Delete all agents ending with "-v1" (with confirmation)
+aif-workflow-helper --delete-all-agents --suffix -v1
+
+# Delete all agents with both prefix and suffix (with confirmation)
+aif-workflow-helper --delete-all-agents --prefix staging- --suffix -test
+
+# Delete all agents without confirmation (DANGEROUS!)
+aif-workflow-helper --delete-all-agents --force
+
+# Delete all matching agents without confirmation
+aif-workflow-helper --delete-all-agents --prefix dev- --suffix -v1 --force
+```
+
+**Interactive Confirmation Example:**
+
+```text
+The following agents will be deleted:
+  - dev-agent-1-v1
+  - dev-agent-2-v1
+  - dev-worker-v1
+
+Total: 3 agent(s)
+
+Are you sure you want to delete these agents? (yes/no): yes
+========== Deleted agent 'dev-agent-1-v1' (ID: asst_abc123) ==========
+========== Deleted agent 'dev-agent-2-v1' (ID: asst_def456) ==========
+========== Deleted agent 'dev-worker-v1' (ID: asst_ghi789) ==========
+========== Successfully deleted 3 of 3 agent(s) ==========
+```
+
+**Safety Features:**
+
+- **Confirmation Prompt**: By default, you'll be asked to confirm before any deletion
+- **--force Flag**: Skip confirmation for automated scripts (use with caution!)
+- **Prefix/Suffix Filtering**: Target specific agents by name pattern
+- **Detailed Logging**: See exactly which agents will be deleted before confirming
+
+**⚠️ Warning:** Deletion is permanent and cannot be undone. Always double-check the agent names before confirming deletion.
 
 ## �📄 Supported File Formats
 

--- a/src/aif_workflow_helper/core/__init__.py
+++ b/src/aif_workflow_helper/core/__init__.py
@@ -12,6 +12,11 @@ from .download import (
     download_agent,
 )
 
+from .delete import (
+    delete_agent_by_name,
+    delete_agents,
+)
+
 from .formats import (
     SUPPORTED_FORMATS,
     EXTENSION_MAP,
@@ -29,6 +34,8 @@ __all__ = [
     "create_or_update_agents_from_files",
     "download_agents",
     "download_agent",
+    "delete_agent_by_name",
+    "delete_agents",
     "SUPPORTED_FORMATS",
     "EXTENSION_MAP",
     "GLOB_PATTERN_MAP", 

--- a/src/aif_workflow_helper/core/delete.py
+++ b/src/aif_workflow_helper/core/delete.py
@@ -1,0 +1,109 @@
+from typing import List, Tuple
+from azure.ai.agents import AgentsClient
+from azure.ai.agents.models import Agent
+
+from aif_workflow_helper.utils.logging import logger
+from aif_workflow_helper.utils.validation import validate_agent_name
+from aif_workflow_helper.core.download import get_agent_by_name
+
+
+def delete_agent_by_name(
+    agent_name: str,
+    agent_client: AgentsClient,
+    prefix: str = "",
+    suffix: str = ""
+) -> bool:
+    """Delete a single agent by name.
+    
+    Args:
+        agent_name: Agent name excluding optional prefix/suffix
+        agent_client: Client used to retrieve and delete the agent
+        prefix: Prefix applied to the stored agent name in the service
+        suffix: Suffix applied to the stored agent name in the service
+        
+    Returns:
+        True if the agent was deleted successfully; False otherwise
+    """
+    full_agent_name = f"{prefix}{agent_name}{suffix}"
+    validate_agent_name(full_agent_name)
+    
+    try:
+        agent = get_agent_by_name(full_agent_name, agent_client)
+        
+        if not agent:
+            logger.warning(f"Agent with name '{full_agent_name}' not found.")
+            return False
+        
+        # Delete the agent
+        agent_client.delete_agent(agent.id)
+        logger.info(f"Successfully deleted agent '{full_agent_name}' (ID: {agent.id})")
+        return True
+        
+    except Exception as e:
+        logger.error(f"Error deleting agent '{full_agent_name}': {e}")
+        return False
+
+
+def get_matching_agents(
+    agent_client: AgentsClient,
+    prefix: str = "",
+    suffix: str = ""
+) -> List[Agent]:
+    """Get all agents matching the prefix/suffix filter.
+    
+    Args:
+        agent_client: Client used to list agents
+        prefix: Only include agents whose names start with this value
+        suffix: Only include agents whose names end with this value
+        
+    Returns:
+        List of matching agent objects
+    """
+    agent_list = list(agent_client.list_agents())
+    
+    # Filter agents by prefix and suffix
+    # Only apply filters if they are non-empty strings
+    matching_agents = []
+    for agent in agent_list:
+        matches = True
+        if prefix and not agent.name.startswith(prefix):
+            matches = False
+        if suffix and not agent.name.endswith(suffix):
+            matches = False
+        if matches:
+            matching_agents.append(agent)
+    
+    return matching_agents
+
+
+def delete_agents(
+    agent_client: AgentsClient,
+    agent_list: List[Agent]
+) -> Tuple[bool, int]:
+    """Delete a list of agents.
+    
+    Args:
+        agent_client: Client used to delete agents
+        agent_list: List of agent objects to delete
+        
+    Returns:
+        Tuple of (success: bool, deleted_count: int)
+    """
+    if not agent_list:
+        logger.info("No agents to delete.")
+        return True, 0
+    
+    success = True
+    deleted_count = 0
+    
+    for agent in agent_list:
+        try:
+            agent_client.delete_agent(agent.id)
+            logger.info(f"Deleted agent '{agent.name}' (ID: {agent.id})")
+            deleted_count += 1
+        except Exception as e:
+            logger.error(f"Failed to delete agent '{agent.name}': {e}")
+            success = False
+    
+    logger.info(f"Successfully deleted {deleted_count} of {len(agent_list)} agent(s)")
+    return success, deleted_count

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -1,0 +1,354 @@
+"""
+Tests for the delete module functionality.
+"""
+
+import pytest
+from unittest.mock import Mock, patch, call
+from azure.ai.agents.models import Agent
+
+from aif_workflow_helper.core.delete import (
+    delete_agent_by_name,
+    delete_agents,
+    get_matching_agents
+)
+
+
+@pytest.fixture
+def mock_agent():
+    """Create a mock agent for testing."""
+    agent = Mock(spec=Agent)
+    agent.id = "agent-123"
+    agent.name = "test-agent"
+    return agent
+
+
+@pytest.fixture
+def mock_agent_with_prefix():
+    """Create a mock agent with prefix for testing."""
+    agent = Mock(spec=Agent)
+    agent.id = "agent-456"
+    agent.name = "dev-test-agent"
+    return agent
+
+
+@pytest.fixture
+def mock_agent_with_prefix_suffix():
+    """Create a mock agent with prefix and suffix for testing."""
+    agent = Mock(spec=Agent)
+    agent.id = "agent-789"
+    agent.name = "dev-test-agent-v1"
+    return agent
+
+
+class TestDeleteAgentByName:
+    """Tests for the delete_agent_by_name function."""
+    
+    def test_delete_agent_by_name_success(self, mock_agent_client, mock_agent):
+        """Test successful deletion."""
+        with patch('aif_workflow_helper.core.delete.get_agent_by_name', return_value=mock_agent):
+            result = delete_agent_by_name(
+                agent_name="test-agent",
+                agent_client=mock_agent_client
+            )
+            assert result is True
+            mock_agent_client.delete_agent.assert_called_once_with(mock_agent.id)
+    
+    def test_delete_agent_by_name_not_found(self, mock_agent_client):
+        """Test deletion when agent is not found."""
+        with patch('aif_workflow_helper.core.delete.get_agent_by_name', return_value=None):
+            result = delete_agent_by_name(
+                agent_name="missing-agent",
+                agent_client=mock_agent_client
+            )
+            assert result is False
+            mock_agent_client.delete_agent.assert_not_called()
+    
+    def test_delete_agent_by_name_with_prefix(self, mock_agent_client, mock_agent_with_prefix):
+        """Test deletion with prefix."""
+        with patch('aif_workflow_helper.core.delete.get_agent_by_name', return_value=mock_agent_with_prefix):
+            result = delete_agent_by_name(
+                agent_name="test-agent",
+                agent_client=mock_agent_client,
+                prefix="dev-"
+            )
+            assert result is True
+            mock_agent_client.delete_agent.assert_called_once_with(mock_agent_with_prefix.id)
+    
+    def test_delete_agent_by_name_with_suffix(self, mock_agent_client, mock_agent):
+        """Test deletion with suffix."""
+        mock_agent.name = "test-agent-v1"
+        with patch('aif_workflow_helper.core.delete.get_agent_by_name', return_value=mock_agent):
+            result = delete_agent_by_name(
+                agent_name="test-agent",
+                agent_client=mock_agent_client,
+                suffix="-v1"
+            )
+            assert result is True
+            mock_agent_client.delete_agent.assert_called_once_with(mock_agent.id)
+    
+    def test_delete_agent_by_name_with_prefix_and_suffix(self, mock_agent_client, mock_agent_with_prefix_suffix):
+        """Test deletion with both prefix and suffix."""
+        with patch('aif_workflow_helper.core.delete.get_agent_by_name', return_value=mock_agent_with_prefix_suffix):
+            result = delete_agent_by_name(
+                agent_name="test-agent",
+                agent_client=mock_agent_client,
+                prefix="dev-",
+                suffix="-v1"
+            )
+            assert result is True
+            mock_agent_client.delete_agent.assert_called_once_with(mock_agent_with_prefix_suffix.id)
+    
+    def test_delete_agent_by_name_api_error(self, mock_agent_client, mock_agent):
+        """Test handling of API errors during deletion."""
+        with patch('aif_workflow_helper.core.delete.get_agent_by_name', return_value=mock_agent):
+            mock_agent_client.delete_agent.side_effect = Exception("API Error")
+            result = delete_agent_by_name(
+                agent_name="test-agent",
+                agent_client=mock_agent_client
+            )
+            assert result is False
+
+
+class TestGetMatchingAgents:
+    """Tests for the get_matching_agents function."""
+    
+    def test_get_matching_agents_no_filter(self, mock_agent_client):
+        """Test getting all agents when no filter is provided."""
+        agents = [
+            Mock(id="agent-1", name="agent-1"),
+            Mock(id="agent-2", name="agent-2"),
+            Mock(id="agent-3", name="agent-3")
+        ]
+        mock_agent_client.list_agents.return_value = agents
+        
+        result = get_matching_agents(agent_client=mock_agent_client)
+        
+        assert len(result) == 3
+    
+    def test_get_matching_agents_with_prefix(self, mock_agent_client):
+        """Test filtering agents by prefix."""
+        agent1 = Mock()
+        agent1.id = "agent-1"
+        agent1.name = "dev-agent-1"
+        agent2 = Mock()
+        agent2.id = "agent-2"
+        agent2.name = "dev-agent-2"
+        agent3 = Mock()
+        agent3.id = "agent-3"
+        agent3.name = "prod-agent-3"
+        agents = [agent1, agent2, agent3]
+        mock_agent_client.list_agents.return_value = agents
+        
+        result = get_matching_agents(
+            agent_client=mock_agent_client,
+            prefix="dev-"
+        )
+        
+        assert len(result) == 2
+        assert all(a.name.startswith("dev-") for a in result)
+    
+    def test_get_matching_agents_with_suffix(self, mock_agent_client):
+        """Test filtering agents by suffix."""
+        agent1 = Mock()
+        agent1.id = "agent-1"
+        agent1.name = "agent-1-v1"
+        agent2 = Mock()
+        agent2.id = "agent-2"
+        agent2.name = "agent-2-v1"
+        agent3 = Mock()
+        agent3.id = "agent-3"
+        agent3.name = "agent-3-v2"
+        agents = [agent1, agent2, agent3]
+        mock_agent_client.list_agents.return_value = agents
+        
+        result = get_matching_agents(
+            agent_client=mock_agent_client,
+            suffix="-v1"
+        )
+        
+        assert len(result) == 2
+        assert all(a.name.endswith("-v1") for a in result)
+    
+    def test_get_matching_agents_with_prefix_and_suffix(self, mock_agent_client):
+        """Test filtering agents by both prefix and suffix."""
+        agent1 = Mock()
+        agent1.id = "agent-1"
+        agent1.name = "dev-agent-1-v1"
+        agent2 = Mock()
+        agent2.id = "agent-2"
+        agent2.name = "dev-agent-2-v1"
+        agent3 = Mock()
+        agent3.id = "agent-3"
+        agent3.name = "dev-agent-3-v2"
+        agent4 = Mock()
+        agent4.id = "agent-4"
+        agent4.name = "prod-agent-4-v1"
+        agents = [agent1, agent2, agent3, agent4]
+        mock_agent_client.list_agents.return_value = agents
+        
+        result = get_matching_agents(
+            agent_client=mock_agent_client,
+            prefix="dev-",
+            suffix="-v1"
+        )
+        
+        assert len(result) == 2
+        assert all(a.name.startswith("dev-") and a.name.endswith("-v1") for a in result)
+    
+    def test_get_matching_agents_no_matches(self, mock_agent_client):
+        """Test when no agents match the filter."""
+        agent1 = Mock()
+        agent1.id = "agent-1"
+        agent1.name = "test-agent-1"
+        agent2 = Mock()
+        agent2.id = "agent-2"
+        agent2.name = "test-agent-2"
+        agents = [agent1, agent2]
+        mock_agent_client.list_agents.return_value = agents
+        
+        result = get_matching_agents(
+            agent_client=mock_agent_client,
+            prefix="nonexistent-"
+        )
+        
+        assert len(result) == 0
+
+
+class TestDeleteAgents:
+    """Tests for the delete_agents function (bulk deletion)."""
+    
+    def test_delete_agents_success(self, mock_agent_client):
+        """Test successful bulk deletion."""
+        agents = [
+            Mock(id="agent-1", name="test-agent-1"),
+            Mock(id="agent-2", name="test-agent-2"),
+            Mock(id="agent-3", name="test-agent-3")
+        ]
+        
+        success, count = delete_agents(agent_client=mock_agent_client, agent_list=agents)
+        
+        assert success is True
+        assert count == 3
+        assert mock_agent_client.delete_agent.call_count == 3
+        mock_agent_client.delete_agent.assert_has_calls([
+            call("agent-1"),
+            call("agent-2"),
+            call("agent-3")
+        ], any_order=True)
+    
+    def test_delete_agents_empty_list(self, mock_agent_client):
+        """Test bulk deletion when agent list is empty."""
+        success, count = delete_agents(agent_client=mock_agent_client, agent_list=[])
+        
+        assert success is True
+        assert count == 0
+        mock_agent_client.delete_agent.assert_not_called()
+    
+    def test_delete_agents_partial_failure(self, mock_agent_client):
+        """Test bulk deletion with partial failures."""
+        agents = [
+            Mock(id="agent-1", name="test-agent-1"),
+            Mock(id="agent-2", name="test-agent-2"),
+            Mock(id="agent-3", name="test-agent-3")
+        ]
+        
+        # Make the second deletion fail
+        def delete_side_effect(agent_id):
+            if agent_id == "agent-2":
+                raise Exception("API Error")
+        
+        mock_agent_client.delete_agent.side_effect = delete_side_effect
+        
+        success, count = delete_agents(agent_client=mock_agent_client, agent_list=agents)
+        
+        assert success is False
+        assert count == 2  # Two succeeded despite one failure
+        assert mock_agent_client.delete_agent.call_count == 3
+
+
+class TestConfirmDeletion:
+    """Tests for the CLI confirmation prompt function."""
+    
+    def test_confirm_deletion_with_yes(self):
+        """Test that 'yes' input returns True."""
+        from aif_workflow_helper.cli.main import confirm_deletion
+        with patch('builtins.input', return_value='yes'):
+            result = confirm_deletion(['agent-1', 'agent-2'])
+            assert result is True
+    
+    def test_confirm_deletion_with_y(self):
+        """Test that 'y' input returns True."""
+        from aif_workflow_helper.cli.main import confirm_deletion
+        with patch('builtins.input', return_value='y'):
+            result = confirm_deletion(['agent-1'])
+            assert result is True
+    
+    def test_confirm_deletion_with_no(self):
+        """Test that 'no' input returns False."""
+        from aif_workflow_helper.cli.main import confirm_deletion
+        with patch('builtins.input', return_value='no'):
+            result = confirm_deletion(['agent-1'])
+            assert result is False
+    
+    def test_confirm_deletion_with_n(self):
+        """Test that 'n' input returns False."""
+        from aif_workflow_helper.cli.main import confirm_deletion
+        with patch('builtins.input', return_value='n'):
+            result = confirm_deletion(['agent-1'])
+            assert result is False
+    
+    def test_confirm_deletion_with_invalid_input(self):
+        """Test that invalid input returns False."""
+        from aif_workflow_helper.cli.main import confirm_deletion
+        with patch('builtins.input', return_value='maybe'):
+            result = confirm_deletion(['agent-1'])
+            assert result is False
+    
+    def test_confirm_deletion_with_empty_list(self):
+        """Test that empty list returns False."""
+        from aif_workflow_helper.cli.main import confirm_deletion
+        result = confirm_deletion([])
+        assert result is False
+    
+    def test_confirm_deletion_with_eof_error(self):
+        """Test that EOFError returns False."""
+        from aif_workflow_helper.cli.main import confirm_deletion
+        with patch('builtins.input', side_effect=EOFError):
+            result = confirm_deletion(['agent-1'])
+            assert result is False
+    
+    def test_confirm_deletion_with_keyboard_interrupt(self):
+        """Test that KeyboardInterrupt returns False."""
+        from aif_workflow_helper.cli.main import confirm_deletion
+        with patch('builtins.input', side_effect=KeyboardInterrupt):
+            result = confirm_deletion(['agent-1'])
+            assert result is False
+    
+    def test_confirm_deletion_case_insensitive(self):
+        """Test that confirmation is case-insensitive."""
+        from aif_workflow_helper.cli.main import confirm_deletion
+        with patch('builtins.input', return_value='YES'):
+            result = confirm_deletion(['agent-1'])
+            assert result is True
+        
+        with patch('builtins.input', return_value='Y'):
+            result = confirm_deletion(['agent-1'])
+            assert result is True
+    
+    def test_confirm_deletion_with_whitespace(self):
+        """Test that whitespace is stripped from input."""
+        from aif_workflow_helper.cli.main import confirm_deletion
+        with patch('builtins.input', return_value='  yes  '):
+            result = confirm_deletion(['agent-1'])
+            assert result is True
+    
+    def test_confirm_deletion_displays_agent_list(self, capsys):
+        """Test that agent names are displayed to user."""
+        from aif_workflow_helper.cli.main import confirm_deletion
+        with patch('builtins.input', return_value='no'):
+            confirm_deletion(['agent-1', 'agent-2', 'agent-3'])
+            captured = capsys.readouterr()
+            assert 'agent-1' in captured.out
+            assert 'agent-2' in captured.out
+            assert 'agent-3' in captured.out
+            assert 'Total: 3 agent(s)' in captured.out


### PR DESCRIPTION
# Agent Deletion Features

This pull request introduces agent deletion functionality to the CLI, allowing users to delete individual agents or bulk delete agents with optional prefix/suffix filtering. `--delete-agent` for single-agent deletion and `--delete-all-agents` for bulk deletion, with support for prefix/suffix filtering and a `--force` flag to skip confirmation prompts and updates documentation and CLI argument handling to reflect these new features.