### PR TITLE
fix: Sync version files and update release workflow

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.2.0
 commit = True
 tag = False
 message = Bump version: {current_version} → {new_version}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       release_title_prefix: 'Release v'
       prerelease: false
       create_release: true
-      commit_strategy: 'tag_only'
+      commit_strategy: 'commit_and_tag'
       branch_condition: 'refs/heads/main'
     secrets:
       api_token: ${{ secrets.PYPI_API_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ include = ["src*"]
 
 [project]
 name = "aif-workflow-helper"
-version = "0.1.0"
+version = "0.2.0"
 description = "Azure AI Foundry dev workflow helpers"
 authors = [
   { name = "Pete Roden", email = "pete.roden@live.com" }

--- a/src/aif_workflow_helper/__init__.py
+++ b/src/aif_workflow_helper/__init__.py
@@ -20,7 +20,7 @@ from aif_workflow_helper.core.formats import (
     get_file_extension,
 )
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 __all__ = [
     "configure_logging",


### PR DESCRIPTION
## Problem

Version files in the repository were out of sync with PyPI:
- **Repository files**: 0.1.0 (all three version files)
- **PyPI**: 0.2.0 (actual published version)
- **Git tag**: v0.2.0 exists but repo files never updated

### Root Cause
The release workflow uses `commit_strategy: 'tag_only'`, which:
- Updates version files during the build process
- Creates a git tag pointing to the pre-bump commit
- Discards the version file changes (doesn't commit them back)
- Keeps git history clean but causes version desync

## Solution

### 1. Sync Version Files to 0.2.0
Update all three version files to match the current PyPI version:
- `.bumpversion.cfg`: 0.1.0 → 0.2.0
- `pyproject.toml`: 0.1.0 → 0.2.0
- `src/aif_workflow_helper/__init__.py`: 0.1.0 → 0.2.0

### 2. Update Release Workflow Strategy
Change `.github/workflows/release.yml`:
- From: `commit_strategy: 'tag_only'`
- To: `commit_strategy: 'commit_and_tag'`

## Impact

### After This PR
✅ Version files will match PyPI (0.2.0)
✅ Future releases will auto-commit version bumps
✅ Repo version will always reflect published version
✅ No manual sync needed after releases

### Workflow Changes
- Each release will create a "Bump version" commit
- This commit will be pushed before tagging
- Tag will point to the version bump commit
- More commits but better traceability

### Example: Next Release (0.3.0)
1. Trigger release workflow with `minor` bump
2. Workflow automatically:
   - Updates files: 0.2.0 → 0.3.0
   - Commits: "Bump version: 0.2.0 → 0.3.0"
   - Tags: v0.3.0
   - Publishes to PyPI
3. Repo files show 0.3.0 (in sync with PyPI) ✅

## Testing Plan

- [ ] Merge this PR
- [ ] Verify version files show 0.2.0
- [ ] Trigger a test release to TestPyPI (uses `commit_strategy: 'none'`)
- [ ] Trigger actual release to PyPI with `minor` bump (→ 0.3.0)
- [ ] Verify version bump commit appears in git history
- [ ] Verify repo files updated to 0.3.0
- [ ] Verify PyPI has 0.3.0

## Related
Fixes version desync issue reported in repository maintenance.