### PR TITLE
pip install aif-workflow-helper  should be in the readme imho

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,19 +22,19 @@ export PROJECT_ENDPOINT='https://your-resource.services.ai.azure.com/api/project
 
 ### 2. Install the Package
 
-For development (editable install):
-
 ```bash
-pip install -e .
+pip install aif-workflow-helper
 ```
+This will install all required dependencies automatically.
 
-Or for production:
+
+Or, if you have cloned this repository and prefer to install from local source:
 
 ```bash
 pip install .
 ```
 
-This will install all required dependencies automatically.
+For development, see the [Running Tests Locally](#running-tests-locally) section (editable install).
 
 ### 3. Using the CLI (Recommended)
 


### PR DESCRIPTION
as the package is available in pypi, adding pip install aif-workflow-helper as the first option

<img width="471" height="81" alt="image" src="https://github.com/user-attachments/assets/e12593ac-abf4-4369-983d-81c3167ae523" />
